### PR TITLE
Update wsrep.cnf.erb so that mysqladmin does not abort on unknown parameter

### DIFF
--- a/cookbooks/bcpc/templates/default/wsrep.cnf.erb
+++ b/cookbooks/bcpc/templates/default/wsrep.cnf.erb
@@ -16,7 +16,7 @@
 [mysqld_safe]
 
 [client]
-max_allowed_packet=32M
+loose-max_allowed_packet=32M
 
 [mysql]
 max_allowed_packet=32M


### PR DESCRIPTION
Prevent mysqladmin from failing during a ping operation due to it not understanding max_allowed_packet
Fixes issue #171
